### PR TITLE
Changed tutorial to run without a cogserver

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,0 +1,8 @@
+sudo vi /usr/local/share/opencog/scm/opencog/openpsi/main.scm
+line # 14: (cog-logger-set-level! opl "info")
+line # 132: (usleep 100000)
+
+sudo vi /usr/local/share/opencog/scm/opencog/ghost/matcher.scm
+line # 283: (rule-selected (eval-and-select candidate-rules #t)))
+
+sudo cp /opencog/notebooks/guile-jupyter-kernel.scm /usr/local/share/jupyter/kernels/guile-kernel/src/guile-jupyter-kernel.scm

--- a/cogserver_tutorials/Ghost.ipynb
+++ b/cogserver_tutorials/Ghost.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -67,7 +67,7 @@
        "\"172.20.0.2\""
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,16 +135,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<thread 139757951805184 (1befa80)"
+       "#<thread 140079621945088 (23b0a80)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -175,13 +175,37 @@
        ")"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "(ghost \"I eat apples\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((WordNode \"I\")\n",
+       " (WordNode \"want\")\n",
+       " (WordNode \"an\")\n",
+       " (WordNode \"apple\")\n",
+       ")"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(ghost-get-result)"
    ]
   }
  ],

--- a/cogserver_tutorials/Ghost.ipynb
+++ b/cogserver_tutorials/Ghost.ipynb
@@ -6,56 +6,42 @@
    "source": [
     "# GHOST\n",
     "\n",
-    "GHOST (General Holistic Organism Scripting Tool) is a DSL (Domain-Specific Language) designed to allow human authors to script behaviors for artificial characters. GHOST is inspired by ChatScript in its syntax, it uses ECAN to guide the context formation and rule discovery processes, OpenPsi for internal dynamics modulation and goal-driven rule (action) selection, as well as various other OpenCog cognitive algorithms for handling a wider range of situations in more flexible and intelligent ways."
+    "GHOST (General Holistic Organism Scripting Tool) is a DSL (Domain-Specific Language) designed to allow human authors to script behaviors for artificial characters. GHOST is inspired by ChatScript in its syntax, it uses ECAN to guide the context formation and rule discovery processes, OpenPsi for internal dynamics modulation and goal-driven rule (action) selection, as well as various other OpenCog cognitive algorithms for handling a wider range of situations in more flexible and intelligent ways.\n",
+    "\n",
+    "For the sake of simplicity, in this tutorial we don't consider rule's STI so we don't require ECAN running to update STI of GHOST rules. First of all, tell guile where it can find opencog stuff. You might want to add the following line to your .guile so it will do it at startup."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  How To Run\n",
-    "It's recommended to run with ghost_bridge. GHOST will be started automatically when you run ghost_bridge.\n",
-    "\n",
-    "On the other hand, if you want to run GHOST alone, follow the steps below:\n",
-    "\n",
-    "- Start the RelEx server\n",
-    "\n",
-    "Note: You will need to do (set-relex-server-host) if you are running it via Docker.\n",
-    "\n",
-    "- Start the CogServer\n",
-    "\n",
-    " opencog/build/opencog/cogserver/server/cogserver\n",
-    "-  Connect to the CogServer in a new terminal, e.g.\n",
-    "\n",
-    "telnet localhost 17001\n",
-    "-  Load the ECAN module\n",
-    "\n",
-    "loadmodule opencog/build/opencog/attention/libattention.so\n",
-    "-  Start ECAN agents\n",
-    "\n",
-    "agents-start opencog::AFImportanceDiffusionAgent opencog::WAImportanceDiffusionAgent opencog::AFRentCollectionAgent opencog::WARentCollectionAgent\n"
+    "First of all, tell guile where it can find opencog stuff. You might want to add the following line to your .guile so it will do it at startup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(add-to-load-path \"/usr/local/share/opencog/scm\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now load all required modules (this step can take 1-2 minutes when you run the tutorial for the first time)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "#<unspecified>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "(use-modules (opencog)\n",
+    "             (opencog attention)\n",
     "             (opencog nlp)\n",
     "             (opencog nlp relex2logic)\n",
     "             (opencog openpsi)\n",
@@ -67,26 +53,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before creating any rules, run"
+    "Because this tutorial is running in a Docker-based deployment, we need to make this call to find out the IP of the Relex server."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
-     "ename": "unbound-variable",
-     "evalue": "(#f Unbound variable: ~S (ecan-based-ghost-rules) #f)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31munbound-variable\u001b[0;32m",
-      "(#f Unbound variable: ~S (ecan-based-ghost-rules) #f)"
-     ]
+     "data": {
+      "text/plain": [
+       "\"172.20.0.2\""
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
+   "source": [
+    "(set-relex-server-host)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Although we are not using ECAN, we use ECAN-based syntax for rules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "(ecan-based-ghost-rules #t)"
    ]
@@ -95,28 +96,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note, rules being created after running this will be slimmer (preferred) and can only work with this ECAN approach. They are NOT backward-compatible with the test-ghost.\n",
-    "\n",
-    "- Start authoring, e.g."
+    "Enable GHOST to consider any rules regardless its importance (this is required because we are not using ECAN)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "ename": "unbound-variable",
-     "evalue": "(#f Unbound variable: ~S (ghost-parse) #f)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31munbound-variable\u001b[0;32m",
-      "(#f Unbound variable: ~S (ghost-parse) #f)"
-     ]
-    }
-   ],
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(ghost-af-only #f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we're ready to input our rules. This is where your creativity will make the difference. The quality of the rule set is the most important thing to have interesting results with GHOST. You can enter your rules one by one using (ghost-parse) commands or use (ghost-parse-files) to parse rule files. In this tutorial we use a single rules entered manually. To parse one or more files you shaw use:\n",
+    "\n",
+    "(ghost-parse-files \"path/to/the/rule/file1\" \"path/to/the/rule/file2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "(ghost-parse \"#goal: (novelty=0.24) u: (eat apple) I want an apple\")"
    ]
@@ -125,52 +130,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or use ghost-parse-files to parse rule files."
+    "After all rules are set up, start GHOST"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "ename": "unbound-variable",
-     "evalue": "(#f Unbound variable: ~S (ghost-parse-files) #f)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31munbound-variable\u001b[0;32m",
-      "(#f Unbound variable: ~S (ghost-parse-files) #f)"
-     ]
-    }
-   ],
-   "source": [
-    "(ghost-parse-files \"path/to/the/rule/file1\" \"path/to/the/rule/file2\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
+   "execution_count": 7,
    "metadata": {},
-   "source": [
-    "Start GHOST"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
    "outputs": [
     {
-     "ename": "unbound-variable",
-     "evalue": "(#f Unbound variable: ~S (ghost-run) #f)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31munbound-variable\u001b[0;32m",
-      "(#f Unbound variable: ~S (ghost-run) #f)"
-     ]
+     "data": {
+      "text/plain": [
+       "#<thread 139757951805184 (1befa80)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -181,77 +157,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Send some input, e.g."
+    "At this point, you can enter utterances and see what ouputs GHOST will provide based on the set of rules you entered previously. In our tutorial we have only one simple rule, so let's try the following utterance."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
-     "ename": "unbound-variable",
-     "evalue": "(#f Unbound variable: ~S (ghost) #f)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31munbound-variable\u001b[0;32m",
-      "(#f Unbound variable: ~S (ghost) #f)"
-     ]
+     "data": {
+      "text/plain": [
+       "((WordNode \"I\")\n",
+       " (WordNode \"want\")\n",
+       " (WordNode \"an\")\n",
+       " (WordNode \"apple\")\n",
+       ")"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "(ghost \"I eat apples\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The output [INFO] [say] (I want an apple) will then be printed on the CogServer.\n",
-    "\n",
-    "For experimental purpose, you may change the weights (default = 1) of various parameters being used in action selector, by doing **ghost-set-strength-weight, ghost-set-context-weight, ghost-set-sti-weight**, and **ghost-set-urge-weight**, for example:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "ename": "unbound-variable",
-     "evalue": "(#f Unbound variable: ~S (ghost-set-sti-weight) #f)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31munbound-variable\u001b[0;32m",
-      "(#f Unbound variable: ~S (ghost-set-sti-weight) #f)"
-     ]
-    }
-   ],
-   "source": [
-    "(ghost-set-sti-weight 0.5)\n",
-    "(ghost-set-strength-weight 3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
    "display_name": "Guile",
    "language": "scheme",
-   "name": "guile"
+   "name": "guile-kernel"
   },
   "language_info": {
    "codemirror_mode": "scheme",
@@ -259,9 +197,9 @@
    "mimetype": "application/x-scheme",
    "name": "guile",
    "pygments_lexer": "scheme",
-   "version": "2.2.0"
+   "version": "2.0.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/guile-jupyter-kernel.scm
+++ b/guile-jupyter-kernel.scm
@@ -1,0 +1,225 @@
+(use-modules (simple-zmq)
+	     (json)
+	     (srfi srfi-1)
+             (srfi srfi-13))
+
+(include "tools.scm")
+(include "hmac.scm")
+
+(define DELIM "<IDS|MSG>")
+
+(define KERNEL-INFO '(("protocol_version" . "5.3.0")
+		      ("implementation" . "guile Jupyter kernel")
+		      ("implementation_version" . "0.0.2")
+		      ("language_info" .
+		       (("name" . "guile")
+			("version" . "2.0.0")
+			("mimetype" . "application/x-scheme")
+			("file_extension" . ".scm")
+			("pygments_lexer" . "scheme")
+			("codemirror_mode" . "scheme")))
+		      ("banner" . "Guile kernel")
+		      ("help_links" . (("GitHub" . "https://github.com/jerry40/guile-kernel")))
+		      ))
+
+(define notebook-info (json->scm (open-input-file (car (last-pair (command-line))))))
+
+(define (get-notebook-info-atom name) (hash-ref notebook-info name))
+
+;; parse json values
+(define notebook-info-control-port     (get-notebook-info-atom "control_port"))
+(define notebook-info-shell-port       (get-notebook-info-atom "shell_port"))
+(define notebook-info-transport        (get-notebook-info-atom "transport"))
+(define notebook-info-signature-scheme (get-notebook-info-atom "signature_scheme"))
+(define notebook-info-stdin-port       (get-notebook-info-atom "stdin_port"))
+(define notebook-info-heartbeat-port   (get-notebook-info-atom "hb_port"))
+(define notebook-info-ip               (get-notebook-info-atom "ip"))
+(define notebook-info-iopub-port       (get-notebook-info-atom "iopub_port"))
+(define notebook-info-key              (get-notebook-info-atom "key"))
+
+;; execution counter closure
+(define execution-counter (let ((x 0)) (lambda () (begin (set! x (+ x 1)) x))))
+
+(define (create-address port) (string-append notebook-info-transport "://" notebook-info-ip ":" (number->string port)))
+
+;; zeromq context
+(define context (zmq-create-context))
+
+;; adresses
+(define addr-heartbeat (create-address notebook-info-heartbeat-port))
+(define addr-shell     (create-address notebook-info-shell-port))
+(define addr-control   (create-address notebook-info-control-port))
+(define addr-iopub     (create-address notebook-info-iopub-port))
+(define addr-stdin     (create-address notebook-info-stdin-port))
+
+;; sockets
+(define socket-heartbeat (zmq-create-socket context ZMQ_REP))
+(define socket-shell     (zmq-create-socket context ZMQ_ROUTER))
+(define socket-control   (zmq-create-socket context ZMQ_ROUTER))
+(define socket-iopub     (zmq-create-socket context ZMQ_PUB))
+(define socket-stdin     (zmq-create-socket context ZMQ_ROUTER))
+
+;; useful lists
+(define adresses         (list addr-heartbeat addr-shell addr-control addr-iopub addr-stdin))
+(define sockets          (list socket-heartbeat socket-shell socket-control socket-iopub socket-stdin))
+
+;; bind sockets to addressess
+(for-each zmq-bind-socket sockets adresses)
+
+(define (send socket uuid header parent-header metadata content)  
+    (let ((signature (get-signature notebook-info-key
+				    (string-append header
+						   parent-header
+						   metadata
+						   content))))
+      (zmq-send-msg-parts-bytevector socket
+				     (list uuid
+					   (string->bv DELIM)
+					   (string->bv signature)
+					   (string->bv header)
+					   (string->bv parent-header)
+					   (string->bv metadata)
+					   (string->bv content)))))
+
+(define (pub header- state parent-header)
+    (send socket-iopub
+	  #vu8(65)
+	  (header- "status")
+	  parent-header
+	  "{}"
+	  (scm->json-string `(("execution_state" . ,state)))))
+
+(define (pub-busy header- parent-header)
+    (pub header- "busy" parent-header))
+
+(define (pub-idle header- parent-header)
+    (pub header- "idle" parent-header))
+
+(define (heartbeat-handler)
+    (zmq-message-send-bytevector socket-heartbeat
+				 (zmq-message-receive-bytevector socket-heartbeat
+								 (zmq-msg-init)))
+  (heartbeat-handler))
+
+(define (general-handler socket)
+    (begin
+	(catch #t
+            (lambda () 
+		(let* ((parts (zmq-get-msg-parts-bytevector socket))
+			(wire-uuid          (car parts))
+			(wire-delimiter     (bv->string (cadr parts)))
+			(wire-signature     (bv->string (caddr parts)))
+			(wire-header        (json-string->scm (bv->string (list-ref parts 3))))
+			(wire-parent-header (bv->string (list-ref parts 4)))
+			(wire-metadata      (json-string->scm (bv->string (list-ref parts 5))))
+			(wire-content       (json-string->scm (bv->string (list-ref parts 6)))))
+		(let ((msg-type      (hash-ref wire-header "msg_type"))
+			(msg-username  (hash-ref wire-header "username"))
+			(msg-session   (hash-ref wire-header "session"))
+			(msg-version   (hash-ref wire-header "version")))
+			(let ((header- (make-header msg-username msg-session msg-version)))
+			(pub-busy header- (scm->json-string wire-header))
+			((dispatch msg-type) socket wire-uuid header- (scm->json-string wire-header) (scm->json-string wire-metadata) wire-content)
+			(pub-idle header- (scm->json-string wire-header))
+			))
+		)
+            )
+            (lambda (key . args) #f)
+        )
+        (sleep 1)
+        (general-handler socket)
+    )
+)
+
+;; unknown request type, ignore it
+(define (ignore-request socket uuid header- parent-header metadata content) #f)
+
+;; send kernel-info
+(define (reply-kernel-info-request socket uuid header- parent-header metadata content)
+    (send socket
+	  uuid
+	  (header- "kernel_info_reply")
+	  parent-header
+	  metadata
+	  (scm->json-string KERNEL-INFO)))
+
+(define (reply-execute-request socket uuid header- parent-header metadata content)
+    (let ((code              (string-append    "(begin " (hash-ref content "code") ")")) ;; make one s-expression from possible list
+	  (silent            (hash-ref content "silent"))
+	  (store-history     (hash-ref content "store_history"))
+	  (user-expressions  (hash-ref content "user_expressions"))
+	  (allow-stdin       (hash-ref content "allow_stdin"))
+	  (stop-on-error     (hash-ref content "stop_on_error"))
+	  (empty-object      (make-hash-table 1))
+	  (counter           (execution-counter)))
+      (let ((err #f)
+	    (err-key #f)
+	    (evalue #f)
+	    (stacktrace #f)
+	    (result #f)
+	    (send- (lambda (socket msg-type content) (send socket uuid (header- msg-type) parent-header metadata (scm->json-string content))))
+	    )
+	(catch #t
+	  ;; evaluate code + replace #undefined in case an expression returned nothing
+	  (lambda ()
+	    (let* ((str (with-output-to-string
+			    (lambda ()
+			      (write
+			       (eval (with-input-from-string code read) (interaction-environment))))))
+		   (tail (string-suffix-length "#<unspecified>" str)))
+	      (set! result (if (> tail 0)
+			       (string-drop-right str tail)
+			       str))))
+
+	  ;; get error message in case of an exception
+	  (lambda (key . parameters)
+	    (set! err #t) 
+	    (set! err-key (with-output-to-string (lambda () (display key))))
+	    (set! evalue (with-output-to-string (lambda () (display parameters))))
+	    (set! stacktrace (list (colorize err-key) evalue))
+	    )
+	  ;; Capture the stack here:
+	  )
+	(send- socket-iopub "execute_input" `(("code" . ,code)
+					      ("execution_count" . ,counter)))	     
+	(when err
+	  (send- socket-iopub "error"       `(("ename" . ,err-key)
+					      ("evalue" . ,evalue)
+					      ("traceback" . ,stacktrace)))
+	  (send- socket      "execute_reply" `(("status" . "error")
+					       ("execution_count" . ,counter)
+					       ("ename" . ,err-key)
+					       ("evalue" . ,evalue)
+					       ("traceback" . ,stacktrace)
+					       ("payload" . [])
+					       ("user_expressions" . ,empty-object))))
+	(unless err
+	  (send- socket       "execute_reply"   `(("status" . "ok")
+						  ("execution_count" . ,counter)
+						  ("payload" . [])
+						  ("user_expressions" . ,empty-object)))
+	  (unless (string-null? result)
+	    (send- socket-iopub "execute_result"  `(("data" .  (("text/plain" . ,(with-output-to-string (lambda () (display result))))))
+						    ("metadata" . ,empty-object)
+						    ("execution_count" . ,counter))))))))
+
+(define (shutdown socket uuid header- parent-header metadata content)
+    (for-each zmq-close-socket sockets)
+  (zmq-destroy-context context)
+  (quit))
+
+(define dispatch-route
+    `(("kernel_info_request" . ,reply-kernel-info-request)
+      ("execute_request"     . ,reply-execute-request)
+      ("shutdown_request"    . ,shutdown)
+      ("comm_info_request"   . ,ignore-request)
+      ))
+
+(define (dispatch msg-type)
+    (let ((res (assoc-ref dispatch-route msg-type)))
+      (unless res
+	(display
+	 (string-append "\n(WW) unknown message type: " msg-type "\n\n")))
+      (if res res ignore-request)))
+
+(general-handler socket-shell)


### PR DESCRIPTION
Although the tutorial is running without cogserver there are a couple of points to remark

----------------------------------------

(1) Although this tutorial is running using ECAN-based rules and ECAN-based GHOST API, ECAN dynamics itself are disabled.  I could not figure out how to ensure the STI of rules so that GHOST can properly match the rules. Even when I run it using a cogserver (and starting all ECAN agents) OpenPSI could not properly match my rules.

This is a potential problem... or not. I don't know. My strong opinion is that this tutorial should not enter in details regarding ECAN and attention dynamics. I think it should focus in how to write rules and make them match in a proper/sensible way.

----------------------------------------

(2) To run the tutorial, 2 files in the Docker container need to be modified:

/usr/local/share/opencog/scm/opencog/openpsi/main.scm
line # 14: (cog-logger-set-level! opl "info")
line # 132: (usleep 10000000)

/usr/local/share/opencog/scm/opencog/ghost/matcher.scm
line # 283: (rule-selected (eval-and-select candidate-rules #t)))

I don't know what's the proper way to do that so I left it to someone else. I've see that the scm files in /usr/local/share/opencog/scm/opencog/ (in the Docker container) differ from the ones in the opencog repo (the repo used inside the same container).

The change in matcher.scm allows the tutorial to run without ECAN dynamics. The changes in main.scm are a hack to work around the problem I've reported regarding the crash of the Jupyter Notebook after some PSI cycles.

The usleep is the delay between two PSI cycles. The amount I suggested is equivalent to 10s. It's too much, I know, but with this delay the aforementioned crash happens only with a very low probability.
1s is enough to have a good user experience but the crash will probably happen in less then 1 minute after calling (ghost-run).

----------------------------------------

(3) I've tried to track the crash. It happens in ZMQ while Jupyter Notebook is trying to ACCEPT in the socket with the user interface. It seems like the socket suddenly become unavailable. The behavior is really odd because:

a) It is surely related to OpenPSI or GHOST. Changing the sleeping time also changes the probability of the crash. If sleeping time is set too high it never crashes.

b) unless the logger is misguiding my judgement (by not delivering debug messages timely), the PSI thread in charge of running GHOST is always sleeping when the crash happens.

c) The crash happens only in the Notebook. Never in a standalone guile session. Actually, the crash happens in the SCM file called when the Notebook is setup (i.e. in the SCM kernel: simple-zmq.scm).

----------------------------------------

